### PR TITLE
ImageHash hex string serialization

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,2 +1,3 @@
 ---AUTHORS---
 [Dong-hee Na](https://github.com/corona10/) donghee.na92@gmail.com
+[Gustavo Brunoro](https://github.com/brunoro/) git@hitnail.net

--- a/imagehash.go
+++ b/imagehash.go
@@ -70,13 +70,13 @@ func (h *ImageHash) Set(idx int) {
 	h.hash |= 1 << uint(idx)
 }
 
-const strFmt = "%v:%0x"
+const strFmt = "%1s:%016x"
 
-// FromString returns an image hash from a hex representation
-func FromString(s string) (*ImageHash, error) {
+// ImageHashFromString returns an image hash from a hex representation
+func ImageHashFromString(s string) (*ImageHash, error) {
 	var kindStr string
 	var hash uint64
-	_, err := fmt.Sscanf(s, strFmt, kindStr, hash)
+	_, err := fmt.Sscanf(s, strFmt, &kindStr, &hash)
 	if err != nil {
 		return nil, errors.New("Couldn't parse string " + s)
 	}

--- a/imagehash.go
+++ b/imagehash.go
@@ -6,20 +6,21 @@ package goimagehash
 
 import (
 	"errors"
+	"fmt"
 )
 
-// hashKind describes the kinds of hash.
-type hashKind int
+// Kind describes the kinds of hash.
+type Kind int
 
 // ImageHash is a struct of hash computation.
 type ImageHash struct {
 	hash uint64
-	kind hashKind
+	kind Kind
 }
 
 const (
 	// Unknown is a enum value of the unknown hash.
-	Unknown hashKind = iota
+	Unknown Kind = iota
 	// AHash is a enum value of the average hash.
 	AHash
 	//PHash is a enum value of the perceptual hash.
@@ -31,14 +32,14 @@ const (
 )
 
 // NewImageHash function creates a new image hash.
-func NewImageHash(hash uint64, kind hashKind) *ImageHash {
+func NewImageHash(hash uint64, kind Kind) *ImageHash {
 	return &ImageHash{hash: hash, kind: kind}
 }
 
 // Distance method returns a distance between two hashes.
 func (h *ImageHash) Distance(other *ImageHash) (int, error) {
 	if h.GetKind() != other.GetKind() {
-		return -1, errors.New("Image hashes's kind should be identical.")
+		return -1, errors.New("Image hashes's kind should be identical")
 	}
 
 	diff := 0
@@ -60,11 +61,52 @@ func (h *ImageHash) GetHash() uint64 {
 }
 
 // GetKind method returns a kind of image hash.
-func (h *ImageHash) GetKind() hashKind {
+func (h *ImageHash) GetKind() Kind {
 	return h.kind
 }
 
 // Set method sets a bit of index.
 func (h *ImageHash) Set(idx int) {
 	h.hash |= 1 << uint(idx)
+}
+
+const strFmt = "%v:%0x"
+
+// FromString returns an image hash from a hex representation
+func FromString(s string) (*ImageHash, error) {
+	var kindStr string
+	var hash uint64
+	_, err := fmt.Sscanf(s, strFmt, kindStr, hash)
+	if err != nil {
+		return nil, errors.New("Couldn't parse string " + s)
+	}
+
+	kind := Unknown
+	switch kindStr {
+	case "a":
+		kind = AHash
+	case "p":
+		kind = PHash
+	case "d":
+		kind = DHash
+	case "w":
+		kind = WHash
+	}
+	return NewImageHash(hash, kind), nil
+}
+
+// ToString returns a hex representation of the hash
+func (h *ImageHash) ToString() string {
+	kindStr := ""
+	switch h.kind {
+	case AHash:
+		kindStr = "a"
+	case PHash:
+		kindStr = "p"
+	case DHash:
+		kindStr = "d"
+	case WHash:
+		kindStr = "w"
+	}
+	return fmt.Sprintf(strFmt, kindStr, h.hash)
 }

--- a/imagehash_test.go
+++ b/imagehash_test.go
@@ -12,15 +12,15 @@ import (
 func TestNewImageHash(t *testing.T) {
 	for _, tt := range []struct {
 		datas    [][]uint8
-		hash1    hashKind
-		hash2    hashKind
+		hash1    Kind
+		hash2    Kind
 		distance int
 		err      error
 	}{
 		{[][]uint8{{1, 0, 1, 1}, {0, 0, 0, 0}}, Unknown, Unknown, 3, nil},
 		{[][]uint8{{0, 0, 0, 0}, {0, 0, 0, 0}}, Unknown, Unknown, 0, nil},
 		{[][]uint8{{0, 0, 0, 0}, {0, 0, 0, 1}}, Unknown, Unknown, 1, nil},
-		{[][]uint8{{0, 0, 0, 0}, {0, 0, 0, 1}}, Unknown, AHash, -1, errors.New("Image hashes's kind should be identical.")},
+		{[][]uint8{{0, 0, 0, 0}, {0, 0, 0, 1}}, Unknown, AHash, -1, errors.New("Image hashes's kind should be identical")},
 	} {
 		data1 := tt.datas[0]
 		data2 := tt.datas[1]


### PR DESCRIPTION
Added the `ToString` and `FromString` methods, that create a string representation of an ImageHash, following the format: `<first letter of type>:<hex representation of hash`.

Also fixed some go linter complaints.