### PR TITLE
imagehash: Add new serialization API dump/load.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ func main() {
 ## Release Note
 
 ### v0.4.0(TBA)
-- **IMPORTANT** goimagehash does not have compatible with the before version
-when it comes to the serialization based on string. bit set order is changed.
+- **IMPORTANT** goimagehash v0.0.4 does not have compatible with the before
+version when it comes to the serialization.
 
 ### v0.3.0
 - Support DifferenceHashExtend.

--- a/_examples/examples.go
+++ b/_examples/examples.go
@@ -25,8 +25,8 @@ func main() {
 	distance, _ = hash1.Distance(hash2)
 	fmt.Printf("Distance between images: %v\n", distance)
 
-        hash1, _ = goimagehash.PerceptionHash(img1)
-        hash2, _ = goimagehash.PerceptionHash(img2)
-        distance, _ = hash1.Distance(hash2)
-        fmt.Printf("Distance between images: %v\n", distance)
+	hash1, _ = goimagehash.PerceptionHash(img1)
+	hash2, _ = goimagehash.PerceptionHash(img2)
+	distance, _ = hash1.Distance(hash2)
+	fmt.Printf("Distance between images: %v\n", distance)
 }

--- a/_examples/load_and_dump.go
+++ b/_examples/load_and_dump.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"github.com/corona10/goimagehash"
+	"image/jpeg"
+	"os"
+)
+
+func main() {
+	file1, _ := os.Open("sample1.jpg")
+	file2, _ := os.Open("sample2.jpg")
+	defer file1.Close()
+	defer file2.Close()
+	var b bytes.Buffer
+	foo := bufio.NewWriter(&b)
+	img1, _ := jpeg.Decode(file1)
+	img2, _ := jpeg.Decode(file2)
+	hash1, _ := goimagehash.AverageHashExtend(img1, 15)
+	hash2, _ := goimagehash.AverageHashExtend(img2, 15)
+	distance, _ := hash1.Distance(hash2)
+	fmt.Printf("Distance between images: %v\n", distance)
+
+	err := hash1.Dump(foo)
+	if err != nil {
+		fmt.Println(err)
+	}
+	foo.Flush()
+	bar := bufio.NewReader(&b)
+	hash3, err := goimagehash.LoadImageHashExtend(bar)
+	if err != nil {
+		fmt.Println(err)
+	}
+	distance, _ = hash1.Distance(hash3)
+	fmt.Printf("Distance between hash1 and hash3: %v\n", distance)
+	distance, _ = hash2.Distance(hash3)
+	fmt.Printf("Distance between hash2 and hash3: %v\n", distance)
+	fmt.Println(hash1.ToString())
+	fmt.Println(hash2.ToString())
+	fmt.Println(hash3.ToString())
+}


### PR DESCRIPTION
Create a new APIs for serializing purpose which can use
standard io.Reader/io.Writer APIs.

ToString() API will be remain for debugging purpose and
ExtImageHashFromString, ImageHashFromString will be removed after next
version.

- New APIs are added: LoadExtImageHash, LoadImageHash, xxxHash.Dump
- These APIs are deprecated: ExtImageHashFromString, ImageHashFromString