### PR TITLE
Fix typo on the GoDoc for LoadImageHash.

### DIFF
--- a/imagehash.go
+++ b/imagehash.go
@@ -95,7 +95,7 @@ func (h *ImageHash) Dump(w io.Writer) error {
 	return nil
 }
 
-// LoadImageHash method loads a ExtImageHash from io.Reader.
+// LoadImageHash method loads a ImageHash from io.Reader.
 func LoadImageHash(b io.Reader) (*ImageHash, error) {
 	type E struct {
 		Hash uint64


### PR DESCRIPTION
The GoDoc incorrectly specified that the LoadImageHash function produces an ExtImageHash. This function produces an ImageHash, so this corrects the typo.

Thank you for this library - super useful and hoping to contribute in some minor way!