### PR TITLE
feat(phash): add suport to work with size 32

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/arthurhenrique/goimagehash
+module github.com/corona10/goimagehash
 
 require github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/corona10/goimagehash
+module github.com/arthurhenrique/goimagehash
 
 require github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646


### PR DESCRIPTION
Hello, mr @corona10 
imagededup libraries works with phash size 32.
refs: https://github.com/idealo/imagededup/blob/master/imagededup/methods/hashing.py#L436

Could you review please?


Thanks